### PR TITLE
Place LDFLAGS after OBJECTS in compile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ EXECUTABLE=SeqPrep
 
 all: $(SOURCES) $(EXECUTABLE)
 
-$(EXECUTABLE): $(OBJECTS) 
-	$(CC) ${COPTS} $(LDFLAGS) $(OBJECTS) -o $@
+$(EXECUTABLE): $(OBJECTS)
+	$(CC) ${COPTS} $(OBJECTS) $(LDFLAGS) -o $@
 
 install: all
 	-cp $(EXECUTABLE) $(HOME)/bin


### PR DESCRIPTION
I was getting errors like "undefined reference to `gzopen'", so I
found this:

http://stackoverflow.com/questions/9145177/undefined-reference-to-gzopen-error

which told me to put "-lz" after the object names. I tried making that
change in the Makefile, and it fixed things.
