### PR TITLE
Fix for masking overlapping adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Arguments for Adapter/Primer Trimming (Optional):
 	-p <read alignment gap-extension; default = 9>
 	-P <read alignment gap-end; default = 5>
 	-X <read alignment maximum fraction gap cutoff; default = 0.125000>
-        -z <use mask; N will replace adapters>
+	-z <use mask; N will replace adapters>
 
 Optional Arguments for Merging:
 

--- a/utils.h
+++ b/utils.h
@@ -54,7 +54,8 @@ bool read_olap_adapter_trim(SQP sqp, size_t min_ol_adapter,
     unsigned short max_mismatch_adapter[MAX_SEQ_LEN+1],
     unsigned short min_match_reads[MAX_SEQ_LEN+1],
     unsigned short max_mismatch_reads[MAX_SEQ_LEN+1],
-    char qcut);
+    char qcut,
+    bool use_mask);
 bool read_merge(SQP sqp, size_t min_olap,
     unsigned short min_match[MAX_SEQ_LEN+1],
     unsigned short max_mismatch[MAX_SEQ_LEN+1],


### PR DESCRIPTION
Fixes masking errors.  Overlapped adapters were being trimmed.  I also fixed the tab in the readme file.

Before SeqPrep:
```
bases 198712348
read_count 1342651
N_count 0

Length Distribution
148: 1342651	100.00%

Quality Score Distribution
Max qscore:38.7162162162
Min qscore:14.2702702703
Mean qscore:34.1884028515
14.27 to 16.71: 0.95%
16.71 to 19.16: 1.48%
19.16 to 21.60: 2.09%
21.60 to 24.05: 3.57%
24.05 to 26.49: 8.05%
26.49 to 28.94: 18.63%
28.94 to 31.38: 28.60%
31.38 to 33.83: 32.52%
33.83 to 36.27: 60.30%

Maximum percentage of Ns in one read: 0.00%
Percent of Ns in reads: 0.00%
```

After SeqPrep with masking (-z flag):
```
bases 186135604
read_count 1257673
N_count 65392009

Length Distribution
148: 1257673	100.00%

Quality Score Distribution
Max qscore:38.7162162162
Min qscore:14.8716216216
Mean qscore:34.700971712
14.87 to 17.26: 0.35%
17.26 to 19.64: 0.72%
19.64 to 22.03: 1.72%
22.03 to 24.41: 3.10%
24.41 to 26.79: 5.90%
26.79 to 29.18: 16.01%
29.18 to 31.56: 28.60%
31.56 to 33.95: 33.95%
33.95 to 36.33: 63.43%

Maximum percentage of Ns in one read: 79.73%
Percent of Ns in reads: 35.13%
```