### PR TITLE
Specified C99 standard to resolve build issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-c -Wall -O0 -g
+CFLAGS=-c -Wall -O0 -g -std=c99
 #recommended options: -ffast-math -ftree-vectorize -march=core2 -mssse3 -O3
 COPTS=
 LDFLAGS=-lz -lm


### PR DESCRIPTION
Build failed with undefined reference to update_spinner unless compiled with -std=c99 using gcc-4.4.7 on RHEL 6.6. Specifying standard resolves this.